### PR TITLE
Fix: validate --custom-tax argument to prevent TypeError

### DIFF
--- a/mess/workflow/rules/preflight/functions.smk
+++ b/mess/workflow/rules/preflight/functions.smk
@@ -212,7 +212,7 @@ if "input_tsv" not in tsv_cache:
 else:
     tsv_df = tsv_cache["input_tsv"]
 
-if config.args.custom_tax:
+if isinstance(config.args.custom_tax, str):
     if "custom_tax_df" not in tsv_cache:
         custom_tax_df = pd.read_csv(config.args.custom_tax, sep="\t")
         tsv_cache["custom_tax_df"] = custom_tax_df

--- a/mess/workflow/rules/preflight/setup.smk
+++ b/mess/workflow/rules/preflight/setup.smk
@@ -51,7 +51,7 @@ if not os.path.exists(os.path.join(TAXONKIT, "names.dmp")):
 
 
 RANKS = config.args.ranks
-if config.args.custom_tax:
+if isinstance(config.args.custom_tax, str):
     RANKS = ",".join(list(custom_tax_df.columns[1:]))
     TAXONKIT = os.path.join(TAXONKIT, "custom")
 


### PR DESCRIPTION
Fixes #57 

**Description:**
This PR resolves a `TypeError` that occurs when running subcommands like `mess download` that do not have the `--custom-tax` option defined.

The conditional check for `config.args.custom_tax` in `functions.smk` and `setup.smk` has been updated from a simple truthiness test to `isinstance(config.args.custom_tax, str)`.

This change ensures the relevant code block is only entered when a user has actually provided a file path (a string). This makes the shared scripts robust and prevents them from failing when included in workflows with different sets of command-line arguments.